### PR TITLE
Adding note to README about APITestClient

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ func main() {
 }
 ```
 
+To use Nordnet test credentials, try `client := api.NewAPITestClient(cred)`.
+
 ### Feed Client
 
 ```go


### PR DESCRIPTION
Took me quite a while to figure this one out!

I didn't quite understand why my credentials worked on the official Python example but not here. Turns out the example from the docs use the the test API in the example.

So we should at least show that this needs to be explicitly defined. Or we put that as the default in the example.
  